### PR TITLE
Add requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 /__pycache__
+.venv
 *.csb
 *.dae
 *.ctb

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Based majorly off of https://github.com/KillzXGaming/CollisionSceneBinary – cr
 
 Exports Paper Mario: Sticker Star's .csb files to a workable .dae file, and allows that file to be reimported with appropiate octree data in a .ctb file. 
 
+**Setup:**
+
+- You will need [Python](https://www.python.org/) installed
+- To install this program's dependencies, run: `pip install -r requirements.txt`
+
 **Usage:**
 
 - To export to .dae:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+scipy
+pycollada


### PR DESCRIPTION
This will make it easier to install this program's dependencies as a new user.

Also, the .venv addition in the gitignore is because Linux usually forces you to create venvs in order to install pip packages